### PR TITLE
Changeing final "no issues found" output to info, so it does not log to the standard error stream

### DIFF
--- a/lib/snyk-filter.js
+++ b/lib/snyk-filter.js
@@ -154,7 +154,7 @@ function pass(data, passString, passFailMsg) {
     jq.run(query, data, options)
       .then((output) => {
         if (output == 0) {
-          console.warn(
+          console.info(
             `${chalk.yellow(
               data.projectName || data.path
             )} - No issues found after custom filtering`


### PR DESCRIPTION
Logging to the standard error stream (via `console.warn()`) in case snyk-filter finds no issues is counterproductive at least for azure devops pipelines as it causes a script task to show up as an error.

Example pipelines:

No issues found: 
 https://dev.azure.com/cpolzer/Examples/_build/results?buildId=150&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=5caf77c8-9b10-50ef-b5c7-ca89c63e1c86

Issues found:
https://dev.azure.com/cpolzer/Examples/_build/results?buildId=153&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=5caf77c8-9b10-50ef-b5c7-ca89c63e1c86


